### PR TITLE
Restore UnitDB function - Update and improve displayed data

### DIFF
--- a/www/include/Git.php
+++ b/www/include/Git.php
@@ -1,5 +1,7 @@
 <?php
 
+// Improved error handling. Detect when commands fail. Exit script on failure.
+// Removed use of shell_exec (does not reliably detect command failures).
 class Git
 {
     private $repositoryUrl;
@@ -17,20 +19,29 @@ class Git
         $escBranch = escapeshellarg($branch);
 
         if ($sparseFolders) {
-            $this->execute("git clone --filter=blob:none --depth 1 --sparse {$escRepo} --branch {$escBranch} {$escDestDir}");
+            $out = $this->execute("git clone --filter=blob:none --depth 1 --sparse {$escRepo} --branch {$escBranch} {$escDestDir}");
+            print_r($out);
 
             foreach ($sparseFolders as $folder) {
                 $escFolder = escapeshellarg($folder);
-                $this->execute("cd {$escDestDir} && git sparse-checkout add {$escFolder}");
+                $out = $this->execute("cd {$escDestDir} && git sparse-checkout add {$escFolder}");
+                print_r($out);
             }
         } else {
-            $this->execute("git clone {$escRepo} {$escDestDir}");
+            $out = $this->execute("git clone {$escRepo} {$escDestDir}");
+            print_r($out);
         }
     }
 
     private function execute($command)
     {
-        $output = shell_exec($command);
+        $output = null;
+        $retval = null;
+        logDebug($command);
+        exec($command, $output, $retval);
+        logDebug("Returned with status $retval and output: \n");
+        if ($retval != 0) exit ($retval);
+
         return $output;
     }
 }

--- a/www/include/Git.php
+++ b/www/include/Git.php
@@ -1,7 +1,6 @@
 <?php
 
-// Improved error handling. Detect when commands fail. Exit script on failure.
-// Removed use of shell_exec (does not reliably detect command failures).
+// Wrapper for Git, exits on git failures.
 class Git
 {
     private $repositoryUrl;
@@ -20,12 +19,10 @@ class Git
 
         if ($sparseFolders) {
             $out = $this->execute("git clone --filter=blob:none --depth 1 --sparse {$escRepo} --branch {$escBranch} {$escDestDir}");
-            print_r($out);
 
             foreach ($sparseFolders as $folder) {
                 $escFolder = escapeshellarg($folder);
                 $out = $this->execute("cd {$escDestDir} && git sparse-checkout add {$escFolder}");
-                print_r($out);
             }
         } else {
             $out = $this->execute("git clone {$escRepo} {$escDestDir}");
@@ -39,8 +36,12 @@ class Git
         $retval = null;
         logDebug($command);
         exec($command, $output, $retval);
-        logDebug("Returned with status $retval and output: \n");
-        if ($retval != 0) exit ($retval);
+
+        if ($retval != 0) {
+            logDebug("Returned with status $retval and output: \n");
+            print_r($output);
+            exit ($retval);
+        }
 
         return $output;
     }

--- a/www/index.php
+++ b/www/index.php
@@ -1,4 +1,7 @@
 <?php 
+// PHP Issue - There is an issue under PHP 8.3.1. With XDebug enabled, it will cause 100% CPU Usage
+// Disable XDebug, or use an earlier version of PHP - PV
+
 	ini_set('display_errors', 1);
 	error_reporting(E_ALL & ~E_NOTICE);
 	set_error_handler(function($errno, $errstr, $errfile, $errline) {

--- a/www/res/scripts/calculations.php
+++ b/www/res/scripts/calculations.php
@@ -1,28 +1,53 @@
 <?php 
-    function calculateFireCycle($weapon){
+    function calculateFireCycle($weapon, $unitID){
+
+    ///     Muzzle Salvo Size and Muzzle Count
+    $mss = 0;
+    $MuzzleCount = 0;
+    $firecycle = 0;
+
+    ///  Bring in the trueSalvoSize calculation from the DPS to this function.  It should only be in 1 place!
+    if (property_exists($weapon, 'RackBones')) { // dummy weapons dont have racks
+
+        ///     OK, this is a legit weapon, let's set our most basic values.
         $mss = $weapon->MuzzleSalvoSize;
-        if ($mss == 1){
-            $bones = 0;
-            foreach($weapon->RackBones as $rack){
-                $bones += count((array)$rack->MuzzleBones);
+
+        /// 	Now we need determine if the weapon fires from multiple muzzles simultaneously (or close to it).
+        if (property_exists($weapon, 'RackFireTogether') && ($weapon->RackFireTogether == 1)) {
+            /// Count up all the muzzles in all the racks
+            foreach ($weapon->RackBones as $rack) {
+                $MuzzleCount += count((array)$rack->MuzzleBones);
             }
-            return $bones;
+            $firecycle = $mss * $MuzzleCount;
         }
-        else{
-            return $mss * count((array)$weapon->RackBones);            
+        //  Do all real weapons have MuzzleSalvoDelay?
+        //	        else if (property_exists($weapon, 'MuzzleSalvoDelay') && $weapon->MuzzleSalvoDelay == 0) {
+        else if ($weapon->MuzzleSalvoDelay == 0) {
+            /// Count only the muzzles in the first rack, since RackFireTogether is false
+            /// We do not use MuzzleSalvoSize (mss) when MuzzleSalvoDelay is 0.
+            /// Cast to an array, in case it is only a string instead of an array, (PHP 8)
+            $MuzzleCount = count((array)$weapon->RackBones[0]->MuzzleBones);
+            $firecycle =  $MuzzleCount;
+        } else {
+            $firecycle = $mss;
         }
+    }
+
+	return $firecycle;
+
     }
     
     // Source : https://github.com/spooky/unitdb/blob/master/app/js/dps.js
     // (calculations provided by Exotic_retard)
-    function calculateDps($stdClassWeapon, $unitID){
+    function calculateDps($stdClassWeapon, $unitID, $Projectile){
         
         $weapon = arrayCastRecursive($stdClassWeapon); // StdClass are a PAIN to use in PHP
         
-        // Hardcoded exceptions
+        // Hardcoded exceptions - Removed arties, handled by Fragmentation code below
+//            'UEL0103', // lobo
+//            'XSL0103', // zthuee
+
         $specials = [
-            'UEL0103', // lobo
-            'XSL0103', // zthuee
             'DAA0206', // mercy
             'XAA0306' // solace
         ];
@@ -31,7 +56,7 @@
         
         $shots = 1;
         
-        if (isset($weapon["MuzzleSalvoSize"])) $shots = calculateFireCycle($stdClassWeapon);
+        if (isset($weapon["MuzzleSalvoSize"])) $shots = calculateFireCycle($stdClassWeapon, $unitID);
         
         
         // fall back to the old calculation formula for the special snowflakes
@@ -46,7 +71,7 @@
         //    in theory if your total MuzzleSalvoDelay is longer than the reload time your weapon waits for the reload time twice,
         //    but thats pretty much a bug so not taken into account here
         
-        
+        ///  BTW - SpookyDB uses round(), not floor(), based on the values seen there.  Values will not match between DBs.  floor() is the correct method.
         $trueReload = max(0.1*floor(10 / $weapon["RateOfFire"]), 0.1); 
         $trueReload = max(
                 ($weapon["RackSalvoChargeTime"] ?? 0) + ($weapon["RackSalvoReloadTime"] ?? 0) + 
@@ -54,22 +79,31 @@
                 $trueReload
         );
 
-        $trueSalvoSize = 1;
-        if (($weapon["MuzzleSalvoDelay"] ?? 0) > 0) { // if theres no muzzle delay, all muzzles fire at the same time
-            $trueSalvoSize = ($weapon["MuzzleSalvoSize"] ?? 1);
-        } else if ($weapon["RackBones"] && count($weapon["RackBones"]) > 0) { // dummy weapons dont have racks
-            if ($weapon["RackFireTogether"]) {
-              $trueSalvoSize = count($weapon["RackBones"]) * count($weapon["RackBones"][0]["MuzzleBones"]);
-            } else if (count($weapon["RackBones"]) > 0) {
-              $trueSalvoSize = count($weapon["RackBones"][0]["MuzzleBones"]);
-            }
+/*
+	Previous code for calculating missile/projectile count was re-written to improve accuracy and moved to calculateFireCycle.
+	We don't want to calculate fire cycles in two places. Just use the value returned from that function.
+*/
+        $trueSalvoSize = $shots;
+
+        /// Added for Salvation
+        if ($unitID == "XAB2307") {
+            /// Salvation uses a shell that fragments into 6 shells, which then fragments into 6 more.  I'm not going to try to code that. Just multiply by 36.
+            $trueSalvoSize = $trueSalvoSize * 36;
         }
 
-        $trueDamage = $weapon["Damage"]*($weapon["DoTPulses"] ?? 1) + ($weapon["InitialDamage"] ?? 0);
-        
+        $trueDamage = $weapon["Damage"] * ($weapon["DoTPulses"] ?? 1) + ($weapon["InitialDamage"] ?? 0);
+
+        /// Added for weapons with fragmentation shells (Lobo, Zthuee).
+        if (isset($Projectile) && property_exists($Projectile->Physics, 'Fragments')) {
+            $trueSalvoSize = $trueSalvoSize * $Projectile->Physics->Fragments;
+        }
+
         // beam weapons are a thing and do their own thing. yeah good luck working out that.
-        $trueDamage = max((floor(($weapon["BeamLifetime"] ?? 0) / (($weapon["BeamCollisionDelay"] ?? 0)+0.1))+1)*$weapon["Damage"], $trueDamage);
+        $trueDamage = max((floor(($weapon["BeamLifetime"] ?? 0) / (($weapon["BeamCollisionDelay"] ?? 0) + 0.1)) + 1) * $weapon["Damage"], $trueDamage);
+        if ($trueSalvoSize == 0) $trueSalvoSize = 1;  // Adjustment needed for beam weapons
+
         $salvoDamage = $trueSalvoSize * $trueDamage * ($isSpecial ? $shots : 1);
+
         $trueDPS = ($salvoDamage / $trueReload);
 
         return $trueDPS;

--- a/www/res/scripts/calculations.php
+++ b/www/res/scripts/calculations.php
@@ -43,10 +43,7 @@
         
         $weapon = arrayCastRecursive($stdClassWeapon); // StdClass are a PAIN to use in PHP
         
-        // Hardcoded exceptions - Removed arties, handled by Fragmentation code below
-//            'UEL0103', // lobo
-//            'XSL0103', // zthuee
-
+        // Hardcoded exceptions
         $specials = [
             'DAA0206', // mercy
             'XAA0306' // solace
@@ -80,22 +77,23 @@
         );
 
 /*
-	Previous code for calculating missile/projectile count was re-written to improve accuracy and moved to calculateFireCycle.
+	Code for calculating missile/projectile count should only be done in calculateFireCycle.
 	We don't want to calculate fire cycles in two places. Just use the value returned from that function.
 */
         $trueSalvoSize = $shots;
 
-        /// Added for Salvation
-        if ($unitID == "XAB2307") {
-            /// Salvation uses a shell that fragments into 6 shells, which then fragments into 6 more.  I'm not going to try to code that. Just multiply by 36.
-            $trueSalvoSize = $trueSalvoSize * 36;
-        }
-
         $trueDamage = $weapon["Damage"] * ($weapon["DoTPulses"] ?? 1) + ($weapon["InitialDamage"] ?? 0);
 
-        /// Added for weapons with fragmentation shells (Lobo, Zthuee).
+        /// For weapons with fragmentation shells (Lobo, Zthuee, Salvation).
         if (isset($Projectile) && property_exists($Projectile->Physics, 'Fragments')) {
             $trueSalvoSize = $trueSalvoSize * $Projectile->Physics->Fragments;
+            /// Exception for Salvation
+            if ($unitID == "XAB2307") {
+                /// Salvation uses a shell that fragments into 6 shells, which then fragments into 6 more.
+                /// Only first fragmentation is accounted for above.  Hard code the 2nd one by multiplying by 6.
+                $trueSalvoSize = $trueSalvoSize * 6;
+            }
+
         }
 
         // beam weapons are a thing and do their own thing. yeah good luck working out that.

--- a/www/res/scripts/functions.php
+++ b/www/res/scripts/functions.php
@@ -1,23 +1,25 @@
 <?php
 
 //	When debugging, uncomment the following to display errors.
-
+/*
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
-
+*/
 
 include("calculations.php");
-		
-	///////////////////////////////////////
-	///									///
-	///	Functions follow.      			///
-	///									///
-	///////////////////////////////////////
-	
-function print_r2($val){
-        echo '<pre>';
-        print_r($val);
-        echo  '</pre>';
+
+///////////////////////////////////////
+///									///
+///	Functions follow.      			///
+///									///
+///////////////////////////////////////
+
+// Formats output of standard print_r function to make it display on a web page.
+function print_r_web($val)
+{
+	echo '<pre>';
+	print_r($val);
+	echo  '</pre>';
 }
 
 //    For some values, I want to see the decimals, unless they don't exist.

--- a/www/res/scripts/functions.php
+++ b/www/res/scripts/functions.php
@@ -1,12 +1,12 @@
 <?php
-	
-	//	When debugging, uncomment the following to display errors.
-	/*
-		error_reporting(E_ALL);
-		ini_set('display_errors', 1);
-	*/
-    
-    include("calculations.php");
+
+//	When debugging, uncomment the following to display errors.
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+
+include("calculations.php");
 		
 	///////////////////////////////////////
 	///									///
@@ -14,6 +14,23 @@
 	///									///
 	///////////////////////////////////////
 	
+function print_r2($val){
+        echo '<pre>';
+        print_r($val);
+        echo  '</pre>';
+}
+
+//    For some values, I want to see the decimals, unless they don't exist.
+function number_format_unlimited_precision($number, $decimal = '.')
+{
+	$broken_number = explode($decimal, $number);
+	if (count($broken_number) == 2) {
+		return number_format($broken_number[0]) . $decimal . $broken_number[1];
+	} else {
+		return number_format($broken_number[0]);
+	}
+}
+
 	function categorizeUnitData($categoriesOrder, $userSettings, $dataUnits){
 		
 		$finalData = array();
@@ -26,16 +43,17 @@
 			
 			/// This chunk of code can be used to skip units lacking an icon, a preview, or basic general information.
 			/// Useful to avoid displaying debug units.
-			/*
+			/// Filter is >necessary<, in fact, because some of these units can cause the script to fail.
+			/// Added filter to prevent units that don't have a 'faction'.
 			if (!property_exists($item, 'StrategicIconName') ||
 				!property_exists($item, 'General') ||
-				!property_exists($item->General, 'Icon')){
+				!property_exists($item->General, 'Icon') ||
+				!property_exists($item->General, 'FactionName')) {
 				continue;
 			}
-			*/
 			
 			/// Formatting the Faction name to ensure it has good casing : Aeon, Cybran, Seraphim, UEF, Nomads
-			$faction = formatFaction($item->General->FactionName);						
+			$faction = formatFaction($item->General->FactionName);
 			
 			/// Adding the army to the list, given the user said he wanted to see it.
 			if (!in_array($faction, $armies) && in_array($faction, $userSettings['showArmies'])){
@@ -501,10 +519,11 @@
 			/// Checks every unit in the $data to see which ones correspond to the right buildable category
 			/// and populates the $buildable with them
 			foreach($dataUnits as $unit){
-				foreach($thisUnit->Economy->BuildableCategory as $buildableCategory){
+			/// (array) Type cast needed in case BuildableCategory is only a string (for PHP 8)
+				foreach((array)$thisUnit->Economy->BuildableCategory as $buildableCategory){
 					$buildableRequirements = explode(' ', $buildableCategory);
 					$canBuild = true;
-					foreach($buildableRequirements as $requirement){
+					foreach((array)$buildableRequirements as $requirement){
 						if (!in_array($requirement, $unit->Categories) && strtoupper($requirement) != strtoupper($unit->Id)){
 							$canBuild = false;
 						}
@@ -874,21 +893,48 @@
 							'.($thisWeapon->DamageType).'
 						</div>
 					</div>';
-			}	
+			}
+
+
+		/// If the weapon uses a missile, and we have this missile in the $data, lets display more information about the missile
+		///  We need to find the missile/projectile before the DPS calculation, in case it uses a fragmentation weapon.
+			$WeaponProjectile = NULL;
+
+			if (property_exists($thisWeapon, 'ProjectileId')) {
+
+				$foundArr = [];
+				$found = preg_match('~(?<=projectiles\/).*(?=\/)~', $thisWeapon->ProjectileId, $foundArr);
+
+				if ($found) {
+
+					$projectileId = $foundArr[0];
+					/// There has got to be a better way to do this, right?  Should make an array for projectiles at some future point.
+					if (strlen($projectileId) > 0) {
+						/// searching the needle in the haystack...
+						foreach ($dataMissiles as $thisMissile) {
+							if (strtoupper($thisMissile->Id) == strtoupper($projectileId)) {
+								// found it !
+								$WeaponProjectile = $thisMissile;
+								break;
+							}
+						}
+					}
+				}
+			}
             
-            /// Approximate DPS
+			/// Approximate DPS
 			if (property_exists($thisWeapon, 'Damage') &&
 				$thisWeapon->Damage > 0 &&
-                $thisWeapon->WeaponCategory != "Death"){ 
+		                $thisWeapon->WeaponCategory != "Death"){ 
 				echo '<div class="flexColumns weaponLine" style="background-color:'.getFactionColor($info['Faction'], 'bright').';">
 						<div class="littleInfo" style="color:'.getFactionColor($info['Faction'], 'dark').';">
 							<b>Approximate DPS</b>
 						</div>
 						<div class="littleInfoVar" style="color:'.getFactionColor($info['Faction'], 'dark').';">
-							<b>'.format(calculateDps($thisWeapon, $info['Id'])).'</b>
+							<b>'.format(calculateDps($thisWeapon, $info['Id'], $WeaponProjectile)).'</b>
 						</div>
                     </div>';
-            }
+			}
 			
 			/// Specific Damage styled display if the weapon has damage
 			if (property_exists($thisWeapon, 'Damage') &&
@@ -931,7 +977,7 @@
 							Fire cycle
 						</div>
 						<div class="littleInfoVar" >
-							'.calculateFireCycle($thisWeapon).' projectiles / shot
+							'.calculateFireCycle($thisWeapon, $info['Id']).' projectiles / shot
 						</div>
 					</div>';
 			}		
@@ -976,75 +1022,55 @@
 							Nuke damage
 						</div>
 						<div class="littleInfoVar" >
-							'.format($thisWeapon->NukeOuterRingDamage).'-'.format($thisWeapon->NukeInnerRingDamage).'
+							'.format($thisWeapon->NukeInnerRingDamage).'-'.format($thisWeapon->NukeOuterRingDamage).'
 						</div>
 					</div>';
 				
 			}
-			
-			/// If the weapon uses a missile, and we have this missile in the $data, lets display more information about the missile
-			if (property_exists($thisWeapon, 'ProjectileId')){
-				
-				$foundArr = [];
-				$found = preg_match('~(?<=projectiles\/).*(?=\/)~', $thisWeapon->ProjectileId, $foundArr);
-				
-				if ($found){
-					
-					$projectileId = $foundArr[0];
-					
-					if (strlen($projectileId) > 0){
-						/// searching the needle in the haystack...
-						foreach($dataMissiles as $thisMissile){
-							if ($thisMissile->Id == strtoupper($projectileId)){
-								// found it !
-								
-								/// Display the blueprint + github link
-									echo '
-								<div class="flexColumns weaponLine" style="margin-bottom:4px;">
-									<div class="littleInfo" style="text-align:center;" >
-										Missile ID/BP
-									</div>
-									<div class="littleInfoVar"  style="text-align:center;margin:0px;"  >
-										<a class="blueprintLink externalBlueprint" href="https://github.com/FAForever/fa/blob/deploy/fafdevelop/projectiles/'.($projectileId).'">
-											'.($projectileId).'
-										</a>
-									</div>
-								</div>';
-								
-								/// Display cost if any
-								if (property_exists($thisMissile, 'Economy')){
-									$eco = $thisMissile->Economy;
-									echo '
-								<div class="flexRows weaponLine" style="margin-bottom:4px;">
-									<div class="littleInfo" style="text-align:center;" >
-										Missile Cost
-									</div>
-									<div class="littleInfoVar"  style="text-align:center;margin:0px;"  >
-										<div class="flexColumns" style="color:black;" style="text-align:center;" >
-											<div class="energyCost bubbleInfo">
-												<img alt="nrg" style="vertical-align:top;" src="res/img/icons/energy.png"> '.format($eco->BuildCostEnergy).'
-												<span class="bubbleText">Energy cost</span>
-											</div>
-											<div class="massCost bubbleInfo">
-												<img alt="mss" style="vertical-align:top;" src="res/img/icons/mass.png"> '.format($eco->BuildCostMass).'
-												<span class="bubbleText">Mass cost</span>
-											</div>
-											<div class="buildTimeCost bubbleInfo">
-												<img alt="tim" style="vertical-align:top;" src="res/img/icons/time.png"> '.format($eco->BuildTime).'
-												<span class="bubbleText">Build time</span>
-											</div>
-										</div>
-									</div>
-								</div>';
-								}
-								break;
-							}
-						}
-						
-					}
-				}
+
+
+		/// Display the blueprint + github link
+			if (isset($projectileId)) {
+				echo '
+					<div class="flexColumns weaponLine" style="margin-bottom:4px;">
+						<div class="littleInfo" style="text-align:center;" >
+							Missile ID/BP
+						</div>
+						<div class="littleInfoVar"  style="text-align:center;margin:0px;"  >
+							<a class="blueprintLink externalBlueprint" href="https://github.com/FAForever/fa/blob/deploy/fafdevelop/projectiles/' . ($projectileId) . '">
+								' . ($projectileId) . '
+							</a>
+						</div>
+					</div>';
 			}
 			
+			/// Display cost if any
+			if (isset($WeaponProjectile) && property_exists($WeaponProjectile, 'Economy')){
+				$eco = $WeaponProjectile->Economy;
+				echo '
+			<div class="flexRows weaponLine" style="margin-bottom:4px;">
+				<div class="littleInfo" style="text-align:center;" >
+					Missile Cost
+				</div>
+				<div class="littleInfoVar"  style="text-align:center;margin:0px;"  >
+					<div class="flexColumns" style="color:black;" style="text-align:center;" >
+						<div class="energyCost bubbleInfo">
+							<img alt="nrg" style="vertical-align:top;" src="res/img/icons/energy.png"> '.format($eco->BuildCostEnergy).'
+							<span class="bubbleText">Energy cost</span>
+						</div>
+						<div class="massCost bubbleInfo">
+							<img alt="mss" style="vertical-align:top;" src="res/img/icons/mass.png"> '.format($eco->BuildCostMass).'
+							<span class="bubbleText">Mass cost</span>
+						</div>
+						<div class="buildTimeCost bubbleInfo">
+							<img alt="tim" style="vertical-align:top;" src="res/img/icons/time.png"> '.format($eco->BuildTime).'
+							<span class="bubbleText">Build time</span>
+						</div>
+					</div>
+				</div>
+			</div>';
+			}
+
 			/// Displaying every generic property now
 			foreach($propertiesToDisplayGreaterThanZero as $thisProp){
 				if (property_exists($thisWeapon, $thisProp) &&
@@ -1054,7 +1080,7 @@
 								'.caseFormat($thisProp).'
 							</div>
 							<div class="littleInfoVar" >
-								'.format($thisWeapon->$thisProp).'
+								'.number_format_unlimited_precision($thisWeapon->$thisProp).'
 							</div>
 						</div>';
 				}
@@ -1067,7 +1093,7 @@
 								'.caseFormat($thisProp).'
 							</div>
 							<div class="littleInfoVar" >
-								'.format($thisWeapon->$thisProp).'
+								'.number_format_unlimited_precision($thisWeapon->$thisProp).'
 							</div>
 						</div>';
 				}
@@ -1079,7 +1105,7 @@
 								'.caseFormat($thisProp).'
 							</div>
 							<div class="littleInfoVar" >
-								'.format($thisWeapon->$thisProp).'
+								'.number_format_unlimited_precision($thisWeapon->$thisProp).'
 							</div>
 						</div>';
 				}
@@ -1393,6 +1419,7 @@
 						color:'.getFactionColor($info['Faction'], 'bright').';">
 						Vision : '.($intel->VisionRadius).'
 					</div>';
+
 			if (property_exists($intel, 'RadarRadius')) echo '
 					<div class="radarRadius"
 						style="
@@ -1419,7 +1446,8 @@
 				// or it has omni or watervisionradius
 				(property_exists($thisUnit, "Intel") && (property_exists($thisUnit->Intel, "WaterVisionRadius") || property_exists($thisUnit->Intel, "OmniRadius")))
 				
-			   ){
+			   )
+			{
 				   
 				echo '
 				<div style="color:'.getFactionColor($info['Faction'], 'bright').';">';
@@ -1462,7 +1490,7 @@
 						"OmniRadius"
 						);
 				
-				foreach($thisUnit->Intel as $key=>$value){
+				foreach((array)$thisUnit->Intel as $key=>$value){
 					if (!in_array($key, $whitelist)){
 						continue;
 					}
@@ -1503,7 +1531,7 @@
 				<div class="flexWrap" style="padding-right:10px;padding-left:10px;">
 					';
 					
-					foreach($abilities as $thisAb){
+					foreach((array)$abilities as $thisAb){
 						
 						echo '<div style="font-weight:bold;
 											text-shadow: 1px 1px black;

--- a/www/update.php
+++ b/www/update.php
@@ -183,7 +183,7 @@ if (!$version)
 
 $repoUrl = "https://github.com/FAForever/fa";
 
-// Changed to .tmp to tmp for better Windows compatibility
+// No leading period for better Windows compatibility
 $repoDir = path("tmp/fa");
 $dataFolder = path("tmp/data");
 


### PR DESCRIPTION
Correct script errors related to differences between PHP 8.x and earlier versions.
Example:
count() generates an error if the argument is not an array object (string being passed).  Previously, a string argument would return a 1.

Correct update.php to read in blueprint data in the correct order (3599 files serve as a baseline, and must be read first).
Improved error handling.
Add code to properly handle reformatted blueprints.

Overhaul of unit DPS and fire cycle calculations to improve accuracy.
General improvements in accuracy and completeness of unit data.
Displaying of Missile cost (nukes, tacticals) restored.
All code for calculating missile/projectile counts was re-written to improve accuracy. Moved all such code to calculateFireCycle, to eliminate duplication.

Added filter to prevent units that don't have a 'faction' from causing the script to fail.
