### PR TITLE
Fix parsing of fire rates

### DIFF
--- a/www/res/scripts/luaToPhp.php
+++ b/www/res/scripts/luaToPhp.php
@@ -33,7 +33,7 @@ function trimval($str)
   $str = trim($str);
 
   // Evaluated numbers used in fire rates like '10/10'
-  if (preg_match('/^((?:[0-9\.]+ *[\/+-] *)*[0-9\.]+),?$/', $str, $matches))
+  if (preg_match('/^((?:[0-9\.]+\w*[\/+-]\w*)*[0-9\.]+),?$/', $str, $matches))
   {
     eval('$str = ' . $matches[1] . ';');
     return (float)$str == (int)$str ? (int)$str : (float)$str;

--- a/www/res/scripts/luaToPhp.php
+++ b/www/res/scripts/luaToPhp.php
@@ -33,7 +33,7 @@ function trimval($str)
   $str = trim($str);
 
   // Evaluated numbers used in fire rates like '10/10'
-  if (preg_match('/^((?:[0-9\.]+\w*[\/+-]\w*)*[0-9\.]+),?$/', $str, $matches))
+  if (preg_match('/^((?:[0-9\.]+\w*[\*\/+-]\w*)*[0-9\.]+),?$/', $str, $matches))
   {
     eval('$str = ' . $matches[1] . ';');
     return (float)$str == (int)$str ? (int)$str : (float)$str;

--- a/www/res/scripts/luaToPhp.php
+++ b/www/res/scripts/luaToPhp.php
@@ -31,6 +31,14 @@
 function trimval($str)
 {
   $str = trim($str);
+
+  // Evaluated numbers used in fire rates like '10/10'
+  if (preg_match('/^((?:[0-9\.]+ *[\/+-] *)*[0-9\.]+),?$/', $str, $matches))
+  {
+    eval('$str = ' . $matches[1] . ';');
+    return (float)$str == (int)$str ? (int)$str : (float)$str;
+  }
+  
   if (substr($str,0,1)=="\""){
     
     $str  = trim(substr($str,1,strlen($str)));


### PR DESCRIPTION
Fixes this error:
`ErrorException: A non-numeric value encountered in /var/www/html/res/scripts/calculations.php on line 72`

Caused by https://github.com/FAForever/fa/pull/6271 changing fire rates from rate numbers to tick interval expressions.